### PR TITLE
Add `isDirty` functionality

### DIFF
--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -152,6 +152,9 @@ If the `Editable` is `ReadOnly` then we return False.
     Editable.Editable "old" "new"
         |> Editable.isDirty  --> True
 
+    Editable.ReadOnly "old"
+        |> Editable.isDirty  --> False
+
 -}
 isDirty : Editable a -> Bool
 isDirty x =
@@ -167,6 +170,9 @@ If the `Editable` is `ReadOnly` then we return False.
 
     Editable.Editable "old" "new"
         |> Editable.isDirtyWith (==)  --> True
+
+    Editable.ReadOnly "old"
+        |> Editable.isDirtyWith (==)  --> False
 
 -}
 isDirtyWith : (a -> a -> Bool) -> Editable a -> Bool

--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -165,7 +165,7 @@ isDirty x =
 
 If the `Editable` is `ReadOnly` then we return False.
 
-    Editable.Editable 1 2
+    Editable.Editable "old" "old"
         |> Editable.isDirtyWith (/=)  --> False
 
     Editable.Editable "old" "new"

--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -158,7 +158,7 @@ If the `Editable` is `ReadOnly` then we return False.
 -}
 isDirty : Editable a -> Bool
 isDirty x =
-    isDirtyWith (==) x
+    isDirtyWith (/=) x
 
 
 {-| Determines if a modified value has changed from the saved one, by a provided function.
@@ -166,13 +166,13 @@ isDirty x =
 If the `Editable` is `ReadOnly` then we return False.
 
     Editable.Editable 1 2
-        |> Editable.isDirtyWith (==)  --> False
+        |> Editable.isDirtyWith (/=)  --> False
 
     Editable.Editable "old" "new"
-        |> Editable.isDirtyWith (==)  --> True
+        |> Editable.isDirtyWith (/=)  --> True
 
     Editable.ReadOnly "old"
-        |> Editable.isDirtyWith (==)  --> False
+        |> Editable.isDirtyWith (/=)  --> False
 
 -}
 isDirtyWith : (a -> a -> Bool) -> Editable a -> Bool

--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -7,12 +7,15 @@ module Editable
         , save
         , update
         , value
+        , isDirty
+        , isDirtyWith
         )
 
 {-| Editable represents a value that can be read-only or editable.
-`ReadOnly a` holds the locked value and `Editable a a`  holds both the old and the newly modified value.
+`ReadOnly a` holds the locked value and `Editable a a` holds both the old and the newly modified value.
 
-@docs Editable, cancel, edit, map, save, update, value
+@docs Editable, cancel, edit, map, save, update, value, isDirty, isDirtyWith
+
 -}
 
 
@@ -23,6 +26,7 @@ module Editable
         case editable of
             Editable saved modified ->
                 input [ defaultValue modified ] []
+
             ReadOnly saved ->
                 text saved
 
@@ -127,6 +131,7 @@ cancel x =
 
     Editable.Editable "old" "new
         |> Editable.value  --> "new"
+
 -}
 value : Editable a -> a
 value x =
@@ -136,3 +141,40 @@ value x =
 
         ReadOnly value ->
             value
+
+
+{-| Determines if a modified value has changed from the saved one, by checking equality of both values.
+
+If the `Editable` is `ReadOnly` then we return False.
+
+    Editable.Editable "old" "old"
+        |> Editable.isDirty  --> False
+
+    Editable.Editable "old" "new"
+        |> Editable.isDirty  --> True
+
+-}
+isDirty : Editable a -> Bool
+isDirty x =
+    isDirtyWith (==) x
+
+
+{-| Determines if a modified value has changed from the saved one, by a provided function.
+
+If the `Editable` is `ReadOnly` then we return False.
+
+    Editable.Editable 1 2
+        |> Editable.isDirtyWith (==)  --> False
+
+    Editable.Editable "old" "new"
+        |> Editable.isDirtyWith (==)  --> True
+
+-}
+isDirtyWith : (a -> a -> Bool) -> Editable a -> Bool
+isDirtyWith f x =
+    case x of
+        ReadOnly _ ->
+            False
+
+        Editable saved modified ->
+            f saved modified

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -105,4 +105,18 @@ all =
                         |> Editable.value
                         |> Expect.equal a
             ]
+        , describe "#isDirty"
+            [ fuzz2 string string "determines if a modified value is different from the saved one." <|
+                \a b ->
+                    Editable a b
+                        |> Editable.isDirty
+                        |> Expect.equal (a == b)
+            , fuzz2 string string "return False if a `Editable` is `ReadOnly`." <|
+                \a b ->
+                    Editable a b
+                        |> Editable.edit
+                        |> Editable.save
+                        |> Editable.isDirty
+                        |> Expect.equal False
+            ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -110,7 +110,7 @@ all =
                 \a b ->
                     Editable a b
                         |> Editable.isDirty
-                        |> Expect.equal (a == b)
+                        |> Expect.equal (a /= b)
             , fuzz2 string string "return False if `Editable` is `ReadOnly`." <|
                 \a b ->
                     Editable a b
@@ -124,7 +124,7 @@ all =
                 \a b ->
                     Editable a b
                         |> Editable.isDirtyWith (==)
-                        |> Expect.equal (a == b)
+                        |> Expect.equal (a /= b)
             , fuzz2 string string "return False if `Editable` is `ReadOnly`." <|
                 \a b ->
                     Editable a b

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -123,14 +123,14 @@ all =
             [ fuzz2 string string "determines if a modified value is different from the saved one." <|
                 \a b ->
                     Editable a b
-                        |> Editable.isDirtyWith (==)
+                        |> Editable.isDirtyWith (/=)
                         |> Expect.equal (a /= b)
             , fuzz2 string string "return False if `Editable` is `ReadOnly`." <|
                 \a b ->
                     Editable a b
                         |> Editable.edit
                         |> Editable.save
-                        |> Editable.isDirtyWith (==)
+                        |> Editable.isDirtyWith (/=)
                         |> Expect.equal False
             ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -111,12 +111,26 @@ all =
                     Editable a b
                         |> Editable.isDirty
                         |> Expect.equal (a == b)
-            , fuzz2 string string "return False if a `Editable` is `ReadOnly`." <|
+            , fuzz2 string string "return False if `Editable` is `ReadOnly`." <|
                 \a b ->
                     Editable a b
                         |> Editable.edit
                         |> Editable.save
                         |> Editable.isDirty
+                        |> Expect.equal False
+            ]
+        , describe "#isDirtyWith"
+            [ fuzz2 string string "determines if a modified value is different from the saved one." <|
+                \a b ->
+                    Editable a b
+                        |> Editable.isDirtyWith (==)
+                        |> Expect.equal (a == b)
+            , fuzz2 string string "return False if `Editable` is `ReadOnly`." <|
+                \a b ->
+                    Editable a b
+                        |> Editable.edit
+                        |> Editable.save
+                        |> Editable.isDirtyWith (==)
                         |> Expect.equal False
             ]
         ]


### PR DESCRIPTION
fixes #3 

Still WIP, but opened for possible early review.

@stoeffel seems there's no Travis integration, and I wasn't able to execute tests with `elm-test ./Tests.elm` -- could you indicate how you run the tests?

(Travis integration could be added in a follow up probably)