### PR TITLE
Remove `update` in favor of calling `map` directly

### DIFF
--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -42,7 +42,7 @@ type Editable a
 
     Editable.ReadOnly "old"
         |> Editable.edit
-        |> Editable.update "new" --> Editable "old" "new"
+        |> Editable.update (always "new") --> Editable "old" "new"
 
 -}
 edit : Editable a -> Editable a
@@ -77,15 +77,18 @@ map f x =
 {-| Updates an `Editable` and doesn't change a `ReadOnly`.
 
     Editable.ReadOnly "old"
-        |> Editable.update "new"  --> ReadOnly "old"
+        |> Editable.update (always "new")  --> ReadOnly "old"
 
     Editable.Editable "old" "old"
-        |> Editable.update "new"  --> Editable "old" "new"
+        |> Editable.update (always "new")  --> Editable "old" "new"
+
+    Editable.Editable "old" "new"
+        |> Editable.update (\val -> val ++ "er")  --> Editable "old" "newer"
 
 -}
-update : a -> Editable a -> Editable a
-update value =
-    map (always value)
+update : (a -> a) -> Editable a -> Editable a
+update f =
+    map f
 
 
 {-| Save a modified value. This puts the modified value into the context of `ReadOnly`.
@@ -95,7 +98,7 @@ update value =
 
     Editable.ReadOnly "old"
         |> Editable.edit
-        |> Editable.update "new"
+        |> Editable.update (always "new")
         |> Editable.save          --> ReadOnly "new"
 
 -}

--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -9,14 +9,13 @@ module Editable
         , isReadOnly
         , map
         , save
-        , update
         , value
         )
 
 {-| Editable represents a value that can be read-only or editable.
 `ReadOnly a` holds the locked value and `Editable a a` holds both the old and the newly modified value.
 
-@docs Editable, cancel, edit, isDirty, isDirtyWith, isEditable, isReadOnly, map, save, update, value
+@docs Editable, cancel, edit, isDirty, isDirtyWith, isEditable, isReadOnly, map, save, value
 
 -}
 
@@ -42,7 +41,7 @@ type Editable a
 
     Editable.ReadOnly "old"
         |> Editable.edit
-        |> Editable.update (always "new") --> Editable "old" "new"
+        |> Editable.map (always "new") --> Editable "old" "new"
 
 -}
 edit : Editable a -> Editable a
@@ -55,13 +54,20 @@ edit x =
             Editable value value
 
 
-{-| Apply a function to an `Editable`.
+{-| Apply a function to an `Editable`. This is the function you will call in
+order to update the value of an `Editable.Editable`.
 
     Editable.ReadOnly "old"
         |> Editable.map String.toUpper --> ReadOnly "old"
 
     Editable.Editable "old" "old"
         |> Editable.map String.toUpper --> Editable "old" "OLD"
+
+    Editable.Editable "old" "new"
+        |> Editable.map (\val -> val ++ "er")  --> Editable "old" "newer"
+
+    Editable.Editable "old" "new"
+        |> Editable.map (always "new") --> Editable "old" "new"
 
 -}
 map : (a -> a) -> Editable a -> Editable a
@@ -74,23 +80,6 @@ map f x =
             ReadOnly saved
 
 
-{-| Updates an `Editable` and doesn't change a `ReadOnly`.
-
-    Editable.ReadOnly "old"
-        |> Editable.update (always "new")  --> ReadOnly "old"
-
-    Editable.Editable "old" "old"
-        |> Editable.update (always "new")  --> Editable "old" "new"
-
-    Editable.Editable "old" "new"
-        |> Editable.update (\val -> val ++ "er")  --> Editable "old" "newer"
-
--}
-update : (a -> a) -> Editable a -> Editable a
-update f =
-    map f
-
-
 {-| Save a modified value. This puts the modified value into the context of `ReadOnly`.
 
     Editable.Editable "old" "new"
@@ -98,7 +87,7 @@ update f =
 
     Editable.ReadOnly "old"
         |> Editable.edit
-        |> Editable.update (always "new")
+        |> Editable.map (always "new")
         |> Editable.save          --> ReadOnly "new"
 
 -}

--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -66,7 +66,7 @@ order to update the value of an `Editable.Editable`.
     Editable.Editable "old" "new"
         |> Editable.map (\val -> val ++ "er")  --> Editable "old" "newer"
 
-    Editable.Editable "old" "new"
+    Editable.Editable "old" "old"
         |> Editable.map (always "new") --> Editable "old" "new"
 
 -}

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -63,24 +63,12 @@ all =
                                 |> Editable.map ((++) "?")
                             )
             ]
-        , describe "#update"
-            [ fuzz2 string string "update doesn't set the value if it's ReadOnly" <|
-                \a b ->
-                    ReadOnly a
-                        |> Editable.update (always b)
-                        |> Expect.equal (ReadOnly a)
-            , fuzz2 string string "update sets the value if it's Editable" <|
-                \a b ->
-                    Editable a a
-                        |> Editable.update (always b)
-                        |> Expect.equal (Editable a b)
-            ]
         , describe "#save"
             [ fuzz2 string string "save makes a Editable ReadOnly with the modified value." <|
                 \a b ->
                     ReadOnly a
                         |> Editable.edit
-                        |> Editable.update (always b)
+                        |> Editable.map (always b)
                         |> Editable.save
                         |> Expect.equal (ReadOnly b)
             ]
@@ -89,7 +77,7 @@ all =
                 \a b ->
                     ReadOnly a
                         |> Editable.edit
-                        |> Editable.update (always b)
+                        |> Editable.map (always b)
                         |> Editable.cancel
                         |> Expect.equal (ReadOnly a)
             ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -67,12 +67,12 @@ all =
             [ fuzz2 string string "update doesn't set the value if it's ReadOnly" <|
                 \a b ->
                     ReadOnly a
-                        |> Editable.update b
+                        |> Editable.update (always b)
                         |> Expect.equal (ReadOnly a)
             , fuzz2 string string "update sets the value if it's Editable" <|
                 \a b ->
                     Editable a a
-                        |> Editable.update b
+                        |> Editable.update (always b)
                         |> Expect.equal (Editable a b)
             ]
         , describe "#save"
@@ -80,7 +80,7 @@ all =
                 \a b ->
                     ReadOnly a
                         |> Editable.edit
-                        |> Editable.update b
+                        |> Editable.update (always b)
                         |> Editable.save
                         |> Expect.equal (ReadOnly b)
             ]
@@ -89,7 +89,7 @@ all =
                 \a b ->
                     ReadOnly a
                         |> Editable.edit
-                        |> Editable.update b
+                        |> Editable.update (always b)
                         |> Editable.cancel
                         |> Expect.equal (ReadOnly a)
             ]


### PR DESCRIPTION
When updating records (which is a typical case) with `Editable.WebData` we end up having to write something like this:

```elm
 value =
    editableWebData
        |> Editable.WebData.toEditable
        |> Editable.value

valueUpdated =
    { value | comment = "" }

itemCommentUpdated =
    editableWebData
        |> Editable.WebData.map (Editable.edit >> Editable.update valueUpdated)
```

With this PR we could do with with just:

```elm
itemCommentUpdated =
    editableWebData
        |> Editable.WebData.map (Editable.edit >> Editable.update (\val -> {val |   comment = "" } )
```

@stoeffel if you'd be ok with that approach, I'll update docs and add more tests accordingly.
