### PR TITLE
Split Editable into Saved and Lockable

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,17 +1,19 @@
 {
-    "version": "1.2.0",
-    "summary": "Editable represents a value that can be read-only or editable.",
-    "repository": "https://github.com/stoeffel/editable.git",
-    "license": "BSD3",
-    "source-directories": [
-        "./src"
-    ],
-    "exposed-modules": [
-        "Editable"
-    ],
-    "dependencies": {
-        "elm-lang/core": "5.1.1 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0"
-    },
-    "elm-version": "0.18.0 <= v < 0.19.0"
+  "version": "1.2.0",
+  "summary": "Editable represents a value that can be read-only or editable.",
+  "repository": "https://github.com/stoeffel/editable.git",
+  "license": "BSD3",
+  "source-directories": [
+    "./src"
+  ],
+  "exposed-modules": [
+    "Saved",
+    "Lockable",
+    "Editable"
+  ],
+  "dependencies": {
+    "elm-lang/core": "5.1.1 <= v < 6.0.0",
+    "elm-lang/html": "2.0.0 <= v < 3.0.0"
+  },
+  "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Editable.elm
+++ b/src/Editable.elm
@@ -42,9 +42,10 @@ type alias Editable a =
 
 {-| Makes a `ReadOnly` value `Editable`.
 
-    Editable.ReadOnly "old"
+    Editable.readonly (==) "old"
         |> Editable.edit
-        |> Editable.map (always "new") --> Editable "old" "new"
+        |> Editable.map (always "new")
+        |> Editable.value --> "new"
 
 -}
 edit : Editable a -> Editable a
@@ -53,19 +54,24 @@ edit =
 
 
 {-| Apply a function to an `Editable`. This is the function you will call in
-order to update the value of an `Editable.Editable`.
+order to update the value of an `Editable.editable`.
 
-    Editable.ReadOnly "old"
-        |> Editable.map String.toUpper --> ReadOnly "old"
+    Editable.readonly (==) "old"
+        |> Editable.map String.toUpper
+        |> Editable.value --> "old"
 
-    Editable.Editable "old" "old"
-        |> Editable.map String.toUpper --> Editable "old" "OLD"
+    Editable.editable (==) "old"
+        |> Editable.map String.toUpper
+        |> Editable.value --> "OLD"
 
-    Editable.Editable "old" "new"
-        |> Editable.map (\val -> val ++ "er")  --> Editable "old" "newer"
+    Editable.editable (==) "old"
+        |> Editable.map (always "new")
+        |> Editable.map (\val -> val ++ "er")
+        |> Editable.value --> "newer"
 
-    Editable.Editable "old" "old"
-        |> Editable.map (always "new") --> Editable "old" "new"
+    Editable.editable (==) "old"
+        |> Editable.map (always "new")
+        |> Editable.value --> "new"
 
 -}
 map : (a -> a) -> Editable a -> Editable a
@@ -75,13 +81,16 @@ map f x =
 
 {-| Save a modified value. This puts the modified value into the context of `ReadOnly`.
 
-    Editable.Editable "old" "new"
-        |> Editable.save          --> ReadOnly "new"
+    Editable.editable (==) "old"
+        |> Editable.map (always "new")
+        |> Editable.save
+        |> Editable.value --> "new"
 
-    Editable.ReadOnly "old"
+    Editable.readonly (==) "old"
         |> Editable.edit
         |> Editable.map (always "new")
-        |> Editable.save          --> ReadOnly "new"
+        |> Editable.save
+        |> Editable.value --> "new"
 
 -}
 save : Editable a -> Editable a
@@ -92,8 +101,10 @@ save x =
 
 {-| Cancels a modified value. This puts the old value into the context of `ReadOnly`.
 
-    Editable.Editable "old" "new"
-        |> Editable.cancel       --> ReadOnly "old"
+    Editable.editable (==) "old"
+        |> Editable.map (always "new")
+        |> Editable.cancel
+        |> Editable.value --> "old"
 
 -}
 cancel : Editable a -> Editable a
@@ -104,10 +115,11 @@ cancel x =
 
 {-| Returns the current value of an Editable.
 
-    Editable.ReadOnly "old"
+    Editable.readonly (==) "old"
         |> Editable.value  --> "old"
 
-    Editable.Editable "old" "new"
+    Editable.editable (==) "old"
+        |> Editable.map (always "new")
         |> Editable.value  --> "new"
 
 -}
@@ -118,10 +130,10 @@ value =
 
 {-| Indicates if an `Editable` is in `Editable` state.
 
-    Editable.Editable "old" "old"
+    Editable.editable (==) "old"
         |> Editable.isEditable  --> True
 
-    Editable.ReadOnly "old"
+    Editable.readonly (==) "old"
         |> Editable.isEditable  --> False
 
 -}
@@ -132,10 +144,10 @@ isEditable =
 
 {-| Indicates if an `Editable` is in `ReadOnly` state.
 
-    Editable.Editable "old" "old"
+    Editable.editable (==) "old"
         |> Editable.isReadOnly  --> False
 
-    Editable.ReadOnly "old"
+    Editable.readonly (==) "old"
         |> Editable.isReadOnly  --> True
 
 -}
@@ -148,13 +160,14 @@ isReadOnly =
 
 If the `Editable` is `ReadOnly` then we return False.
 
-    Editable.Editable "old" "old"
+    Editable.editable (==) "old"
         |> Editable.isDirty  --> False
 
-    Editable.Editable "old" "new"
+    Editable.editable (==) "old"
+        |> Editable.map (always "new")
         |> Editable.isDirty  --> True
 
-    Editable.ReadOnly "old"
+    Editable.readonly (==) "old"
         |> Editable.isDirty  --> False
 
 -}

--- a/src/Lockable.elm
+++ b/src/Lockable.elm
@@ -1,17 +1,30 @@
-module Lockable exposing (Lockable, change, lock, locked, map, unlock, value)
+module Lockable exposing (Lockable, change, lock, locked, map, new, unlock, value)
 
 {-| A value that can be locked for writing.
 
 While the value is locked, 'change' operations on it will have no effect.
 
+@docs Lockable
+@docs change
+@docs lock
+@docs locked
+@docs map
+@docs unlock
+@docs value
+@docs new
+
 -}
 
 
+{-| A value that can be in a locked or unlocked state.
+-}
 type Lockable a
     = Locked a
     | Unlocked a
 
 
+{-| Get the value in a `Lockable`.
+-}
 value : Lockable a -> a
 value lockable =
     case lockable of
@@ -22,16 +35,22 @@ value lockable =
             x
 
 
+{-| Lock a value, ensuring `change` calls on it will have no effect.
+-}
 lock : Lockable a -> Lockable a
 lock =
     value >> Locked
 
 
+{-| Unlock a value, ensuring `change` calls will affect it again.
+-}
 unlock : Lockable a -> Lockable a
 unlock =
     value >> Unlocked
 
 
+{-| Check if a `Lockable` is currently locked.
+-}
 locked : Lockable a -> Bool
 locked lockable =
     case lockable of
@@ -42,6 +61,9 @@ locked lockable =
             False
 
 
+{-| Change the value in a `Lockable`. This will only have effect if the
+`Lockable` is currently unlocked.
+-}
 change : (a -> a) -> Lockable a -> Lockable a
 change fn lockable =
     case lockable of
@@ -52,6 +74,9 @@ change fn lockable =
             Unlocked (fn x)
 
 
+{-| Map the value in a `Lockable`. Be careful, this will always work, regardless
+of the current lock state!
+-}
 map : (a -> b) -> Lockable a -> Lockable b
 map fn lockable =
     case lockable of
@@ -60,3 +85,11 @@ map fn lockable =
 
         Unlocked x ->
             Unlocked (fn x)
+
+
+{-| Create a new `Lockable`. The new `Lockable` will start out in a locked
+state.
+-}
+new : a -> Lockable a
+new =
+    Locked

--- a/src/Lockable.elm
+++ b/src/Lockable.elm
@@ -1,0 +1,62 @@
+module Lockable exposing (Lockable, change, lock, locked, map, unlock, value)
+
+{-| A value that can be locked for writing.
+
+While the value is locked, 'change' operations on it will have no effect.
+
+-}
+
+
+type Lockable a
+    = Locked a
+    | Unlocked a
+
+
+value : Lockable a -> a
+value lockable =
+    case lockable of
+        Locked x ->
+            x
+
+        Unlocked x ->
+            x
+
+
+lock : Lockable a -> Lockable a
+lock =
+    value >> Locked
+
+
+unlock : Lockable a -> Lockable a
+unlock =
+    value >> Unlocked
+
+
+locked : Lockable a -> Bool
+locked lockable =
+    case lockable of
+        Locked _ ->
+            True
+
+        Unlocked _ ->
+            False
+
+
+change : (a -> a) -> Lockable a -> Lockable a
+change fn lockable =
+    case lockable of
+        Locked _ ->
+            lockable
+
+        Unlocked x ->
+            Unlocked (fn x)
+
+
+map : (a -> b) -> Lockable a -> Lockable b
+map fn lockable =
+    case lockable of
+        Locked x ->
+            Locked (fn x)
+
+        Unlocked x ->
+            Unlocked (fn x)

--- a/src/Saved.elm
+++ b/src/Saved.elm
@@ -1,6 +1,7 @@
 module Saved
     exposing
-        ( Saved
+        ( Eq
+        , Saved
         , change
         , discard
         , map
@@ -22,6 +23,7 @@ The type takes an equality function to distinguish between the Changed and Saved
 states.
 
 @docs Saved
+@docs Eq
 @docs change
 @docs discard
 @docs map
@@ -41,6 +43,13 @@ type Saved a
     | Changed (Eq a) a a
 
 
+{-| An equality check for a type.
+
+In a lot of cases you can simply pass in (==), but if the type in your `Saved`
+is / contains types that implement their own equality checks, such as `Dict` or
+`Set`, you will need to use those.
+
+-}
 type alias Eq a =
     a -> a -> Bool
 

--- a/src/Saved.elm
+++ b/src/Saved.elm
@@ -1,0 +1,180 @@
+module Saved
+    exposing
+        ( Saved
+        , change
+        , discard
+        , map
+        , new
+        , save
+        , saved
+        , setSaved
+        , value
+        )
+
+{-| A type to keep track of whether a value has been saved.
+
+The value wrapped in `Save` can be in one of three states.
+
+  - Changed: This means changes have been made to a saved value.
+  - Saved: This means a value has been saved, and not changed since.
+
+The type takes an equality function to distinguish between the Changed and Saved
+states.
+
+@docs Saved
+@docs change
+@docs discard
+@docs map
+@docs new
+@docs save
+@docs saved
+@docs setSaved
+@docs value
+
+-}
+
+
+{-| A type representing the saved state of a value.
+-}
+type Saved a
+    = Saved (Eq a) a
+    | Changed (Eq a) a a
+
+
+type alias Eq a =
+    a -> a -> Bool
+
+
+{-| Wrap a value in a `Saved`.
+
+The value passed in is considered the first saved state.
+
+-}
+new : Eq a -> a -> Saved a
+new =
+    Saved
+
+
+{-| Get back a value from a `Saved`.
+-}
+value : Saved a -> a
+value saved =
+    case saved of
+        Saved _ latest ->
+            latest
+
+        Changed _ _ latest ->
+            latest
+
+
+initial : Saved a -> a
+initial saved =
+    case saved of
+        Saved _ initial ->
+            initial
+
+        Changed _ initial _ ->
+            initial
+
+
+eq : Saved a -> Eq a
+eq saved =
+    case saved of
+        Saved eq _ ->
+            eq
+
+        Changed eq _ _ ->
+            eq
+
+
+{-| Change a value.
+-}
+change : (a -> a) -> Saved a -> Saved a
+change fn saved =
+    let
+        same : Eq a
+        same =
+            eq saved
+
+        old : a
+        old =
+            initial saved
+
+        new : a
+        new =
+            fn (value saved)
+    in
+    if same old new then
+        Saved same old
+    else
+        Changed same old new
+
+
+{-| Set the 'saved' value, keeping the current value unchanged.
+
+You might use this is you know your backend has saved a value, but your user
+might have made new changes in the meanwhile.
+
+-}
+setSaved : a -> Saved a -> Saved a
+setSaved newInitial saved =
+    new (eq saved) newInitial
+        |> change (\_ -> value saved)
+
+
+{-| Save the current value.
+-}
+save : Saved a -> Saved a
+save saved =
+    case saved of
+        Saved eq new ->
+            Saved eq new
+
+        Changed eq _ new ->
+            Saved eq new
+
+
+{-| Discard any changes and reset to the saved value.
+-}
+discard : Saved a -> Saved a
+discard saved =
+    case saved of
+        Saved eq saved ->
+            Saved eq saved
+
+        Changed eq saved _ ->
+            Saved eq saved
+
+
+{-| Check if any changes have been made to the value.
+-}
+saved : Saved a -> Bool
+saved saved =
+    case saved of
+        Saved _ _ ->
+            True
+
+        Changed _ _ _ ->
+            False
+
+
+{-| Map over the values in a saved.
+
+Beware that this changes both the initial and the changed value, and so should
+not be used to make changes to the value (for that, use 'change').
+
+As a rule of thumb, if your map function does not go from a type to another type
+and so is `a -> a`, you probably don't want to use this.
+
+Because this function returns a saved with a different type, this function
+requires a new equality test for this type.
+
+-}
+map : Eq b -> (a -> b) -> Saved a -> Saved b
+map newEq fn saved =
+    case saved of
+        Saved _ initial ->
+            Saved newEq (fn initial)
+
+        Changed _ initial latest ->
+            Changed newEq (fn initial) (fn latest)


### PR DESCRIPTION
For a project I recently created a `Saved a` type (included in this PR). I realized it's pretty similar to `Editable`, but without the locking behaviour. Encouraged by Stoeffel I created a PR to propose these ideas. I know this is a pretty big change, so I don't have any expectations that this should or will be merged. If the conclusion here is that we shouldn't go in this direction feel free to close, no bad feelings :).

What is this change?
- It introduces a `Saved a` type which is like `Editable` but without the locking behaviour. It's also passed an equality check at construction removing the need for separate `isDirty` and `isDirthWith` checks.
- The locking behaviour is moved into a `Lockable a` type.
- The `Editable a` has been made into a type alias for `Lockable (Saved a)`. It's API is mostly the same, with these exceptions:
  - It does not export constructors anymore, because it's now a type alias.
  - A equality function needs to be passed when an editable is created, because `Saved a` expects one. As a consequence, `isDirtyWith` has no purpose anymore and was deleted. If we'd like to this change can probably be avoided, by having the `Editable` constructor functions implicitly pass `(==)` as an equality function. 
  - You cannot construct an editable directly with old and new values, because the values passed in might be the same.

I migrated existing tests to show that the current behaviour hasn't changed. If we'd like to go forward with this PR I'd be happy to add extra tests and docs for the `Lockable a` and `Saved a` types.

Looking forward to reading your thoughts!